### PR TITLE
24:00 のパース

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// a wrapper of time.Parse()
+func Parse2400(layout, value string) (time.Time, error) {
+	parsedTime, err := time.Parse(layout, value)
+	if err != nil {
+		if !isHourOutErr(err) {
+			return time.Time{}, err
+		}
+		i := strings.Index(layout, "15")
+		if i == -1 {
+			return time.Time{}, errors.New("stdHour 15 was not found in layout")
+		}
+		newValue := value[:i] + "00" + value[i+2:]
+		parsedTime, err = time.Parse(layout, newValue)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return parsedTime.Add(24 * time.Hour), nil
+	}
+	return parsedTime, nil
+}
+
+func isHourOutErr(err error) bool {
+	switch err.(type) {
+	case *time.ParseError:
+		return strings.Contains(err.Error(), "hour")
+	default:
+		return false
+	}
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParse2400(t *testing.T) {
+	type Pair struct {
+		layout string
+		value  string
+	}
+	testcases := []Pair{
+		{"2006/01/02 15:04", "2021/07/31 24:00"},
+		{"15", "24"},
+		{"", ""},
+		{"1", "2"},
+		{"2006/01/02 15:04:05", "2021/07/31 24:00:00"},
+	}
+	for _, testcase := range testcases {
+		parsedTime, err := Parse2400(testcase.layout, testcase.value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fmt.Println(parsedTime)
+	}
+}


### PR DESCRIPTION
https://github.com/szpp-dev-team/gakujo-api/issues/11 を解決します

## ロジックの説明

24 を 00 にして1日繰り上げする！w

## 動作確認

```console
$ go test -timeout 120s -run ^TestParse2400$ github.com/szpp-dev-team/gakujo-api/util -v -count=1
2021-08-01 00:00:00 +0000 UTC
0000-01-02 00:00:00 +0000 UTC
0000-01-01 00:00:00 +0000 UTC
0000-02-01 00:00:00 +0000 UTC
2021-08-01 00:00:00 +0000 UTC
--- PASS: TestParse2400 (0.00s)
PASS
ok  	github.com/szpp-dev-team/gakujo-api/util	0.414s
```